### PR TITLE
Revert accidental commit to main

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,9 +12,13 @@ repos:
       - id: no-commit-to-branch
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.0
+    rev: v1.83.1
     hooks:
       - id: terraform_fmt
+
+      # To speed up local validation add the following to your ~/.zshrc:
+      # export TF_PLUGIN_CACHE_DIR=$HOME/.terraform.d/plugin-cache
+
       - id: terraform_validate
         args:
           - --hook-config=--retry-once-with-cleanup=true

--- a/global/infra/locals.tf
+++ b/global/infra/locals.tf
@@ -15,7 +15,6 @@ locals {
     }
 
     "plt-lz-backend" = {
-      github_ref                 = var.environment == "sb" ? null : "refs/heads/main"
       github_repositories        = ["google-cloud-terraform-backend"]
       billing_user_group_manager = true
     }
@@ -67,7 +66,6 @@ locals {
       for repository in name.github_repositories : {
         name       = service_account_key
         repository = repository
-        ref        = lookup(local.service_accounts[service_account_key], "github_ref", null)
       }
     ]
   ]) : service_account.repository => service_account }

--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -135,8 +135,7 @@ resource "google_service_account" "github_actions" {
 resource "google_service_account_iam_member" "github_actions" {
   for_each = local.github_repositories
 
-  #member             = "principalSet://iam.googleapis.com/${var.workload_identity_pool_name}/attribute.repository/osinfra-io/${each.value.repository}/attribute.ref/${each.value.ref}}"
-  member             = lookup(each.value, "github_ref", null) == null ? "principalSet://iam.googleapis.com/${var.workload_identity_pool_name}/attribute.repository/osinfra-io/${each.value.repository}" : "principalSet://iam.googleapis.com/${var.workload_identity_pool_name}/attribute.repository/osinfra-io/${each.value.repository}/attribute.ref/${each.value.ref}"
+  member             = "principalSet://iam.googleapis.com/${var.workload_identity_pool_name}/attribute.repository/osinfra-io/${each.value.repository}/attribute.ref/${each.value.ref}}"
   role               = "roles/iam.workloadIdentityUser"
   service_account_id = google_service_account.github_actions[each.value.name].id
 }

--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -135,7 +135,7 @@ resource "google_service_account" "github_actions" {
 resource "google_service_account_iam_member" "github_actions" {
   for_each = local.github_repositories
 
-  member             = "principalSet://iam.googleapis.com/${var.workload_identity_pool_name}/attribute.repository/osinfra-io/${each.value.repository}/attribute.ref/${each.value.ref}}"
+  member             = "principalSet://iam.googleapis.com/${var.workload_identity_pool_name}/attribute.repository/osinfra-io/${each.value.repository}"
   role               = "roles/iam.workloadIdentityUser"
   service_account_id = google_service_account.github_actions[each.value.name].id
 }


### PR DESCRIPTION
Enabled a bit better branch protection at the vscode level since admins can bypass in GitHub.