### PR TITLE
Remove `terraform-google-kubernetes-engine-onboarding` repository

### DIFF
--- a/global/infra/locals.tf
+++ b/global/infra/locals.tf
@@ -52,7 +52,6 @@ locals {
         "terraform-google-cloud-nat",
         "terraform-google-cloud-sql",
         "terraform-google-kubernetes-engine",
-        "terraform-google-kubernetes-engine-onboarding",
         "terraform-google-project",
         "terraform-google-storage-bucket",
         "terraform-google-subnet",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed an unused module from the infrastructure configuration to streamline setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->